### PR TITLE
check variable 'seconds' if null in YouTubePlayerBridge.java

### DIFF
--- a/YouTubePlayer/src/main/java/com/pierfrancescosoffritti/youtubeplayer/YouTubePlayerBridge.java
+++ b/YouTubePlayer/src/main/java/com/pierfrancescosoffritti/youtubeplayer/YouTubePlayerBridge.java
@@ -3,6 +3,7 @@ package com.pierfrancescosoffritti.youtubeplayer;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 import android.webkit.JavascriptInterface;
 
 /**
@@ -170,7 +171,8 @@ public class YouTubePlayerBridge {
             @Override
             public void run() {
                 try {
-                    float videoDuration = Float.parseFloat(seconds);
+                    String finalSeconds = TextUtils.isEmpty(seconds) ? "0" : seconds;
+                    float videoDuration = Float.parseFloat(finalSeconds);
                     for (YouTubePlayer.YouTubeListener listener : youTubePlayer.getListeners())
                         listener.onVideoDuration(videoDuration);
                 } catch (NumberFormatException e) {


### PR DESCRIPTION
Fixed this bug

`Fatal Exception: java.lang.NullPointerException
       at java.lang.StringToReal.parseFloat(StringToReal.java:285)
       at java.lang.Float.parseFloat(Float.java:300)
       at com.pierfrancescosoffritti.youtubeplayer.YouTubePlayerBridge$9.run(YouTubePlayerBridge.java:173)
       at android.os.Handler.handleCallback(Handler.java:800)
       at android.os.Handler.dispatchMessage(Handler.java:100)
       at android.os.Looper.loop(Looper.java:194)
       at android.app.ActivityThread.main(ActivityThread.java:5515)
       at java.lang.reflect.Method.invokeNative(Method.java)
       at java.lang.reflect.Method.invoke(Method.java:525)
       at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:833)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:600)
       at dalvik.system.NativeStart.main(NativeStart.java)`