### PR TITLE
cleanup Handler callbacks on destroy

### DIFF
--- a/YouTubePlayer/src/main/java/com/pierfrancescosoffritti/youtubeplayer/YouTubePlayer.java
+++ b/YouTubePlayer/src/main/java/com/pierfrancescosoffritti/youtubeplayer/YouTubePlayer.java
@@ -162,6 +162,12 @@ public class YouTubePlayer extends WebView {
         return youTubeListeners.remove(listener);
     }
 
+    @Override
+    public void destroy() {
+        mainThreadHandler.removeCallbacksAndMessages(null);
+        super.destroy();
+    }
+
     public interface YouTubeListener {
         void onReady();
         void onStateChange(@State.YouTubePlayerState int state);


### PR DESCRIPTION
Fixes a crash on some Android 4 devices when trying to execute JavaScript after the WebView has already been destroyed. E.g. when calling `pauseVideo()` followed by `release()`.